### PR TITLE
os-release: use ID_LIKE="arch"

### DIFF
--- a/bin/update-release-files
+++ b/bin/update-release-files
@@ -6,7 +6,7 @@ cat << __EOF__ > /usr/lib/os-release
 NAME="Antergos Linux"
 PRETTY_NAME="Antergos Linux"
 ID=antergos
-ID_LIKE=archlinux
+ID_LIKE=arch
 ANSI_COLOR="0;36"
 HOME_URL="https://antergos.com/"
 SUPPORT_URL="https://forum.antergos.com/"


### PR DESCRIPTION
Historically speaking, Antergos has used ID_LIKE="archlinux", which is
incorrect, but based on (and promulgating) the confusion caused by
upstream bug https://bugs.archlinux.org/task/58499

The os-release(5) specification states that ID_LIKE should be equal to
the ID of the related (parent?) distribution, and Arch Linux uses
ID="arch"

Why Arch Linux claims to be "like" some mythical ID="archlinux"
distribution, I do not know. However, downstream derivatives should
still be using the correct ID_LIKE, irrespective of what Arch Linux uses
in the same field.